### PR TITLE
Fix missing slash in legacy config path

### DIFF
--- a/Util/Paths.cpp
+++ b/Util/Paths.cpp
@@ -10,7 +10,7 @@ std::string Paths::GetConfigPath()
 {
     struct passwd *pw = getpwuid(getuid());
     std::string home_path = std::string(pw->pw_dir);
-    std::string legacy_config_path = home_path + "/.dolphin-emu";
+    std::string legacy_config_path = home_path + "/.dolphin-emu/";
     std::string mem_watcher_path;
     std::string pipe_path;
 


### PR DESCRIPTION
Because of the missing slash "\~/.dolphin-emuMemoryWatcher" and "\~/dolphin-emuPipes" folders are created instead of ".dolphin-emu/MemoryWatcher" and "./dolphin-emu/Pipes"