### PR TITLE
Punish direction during TURNING

### DIFF
--- a/Tactics/punish.py
+++ b/Tactics/punish.py
@@ -266,7 +266,8 @@ class Punish(Tactic):
 
             facing = smashbot_state.facing == (smashbot_endposition < endposition)
             # Remember that if we're turning, the attack will come out the opposite way
-            if smashbot_state.action == Action.TURNING:
+            # On f1 of smashturn, smashbot hasn't changed directions yet. On/after frame 2, it has. Tilt turn may be a problem.
+            if smashbot_state.action == Action.TURNING and smashbot_state.action_frame == 1:
                 facing = not facing
 
             # Get height of opponent at the targeted frame


### PR DESCRIPTION
Addresses a minor issue with regards to the direction Smashbot is facing. During the Punish tactic, it originally re-assigned facing = not facing during Action.TURNING. However, this is only the case during frame 1 of Action.TURNING, if it is a smash turn, so this was specifically declared.