### PR TITLE
Disable boardsideplatform.py on FOD

### DIFF
--- a/Tactics/approach.py
+++ b/Tactics/approach.py
@@ -20,7 +20,7 @@ class Approach(Tactic):
 
         # If opponent is on a side platform and we're not
         on_main_platform = smashbot_state.y < 1 and smashbot_state.on_ground
-        if opponent_state.y > 1 and opponent_state.on_ground and on_main_platform:
+        if opponent_state.y > 1 and opponent_state.on_ground and on_main_platform and gamestate.stage != melee.enums.Stage.FOUNTAIN_OF_DREAMS:
             self.pickchain(Chains.BoardSidePlatform, [opponent_state.x > 0])
             return
 


### PR DESCRIPTION
Smashbot spams spotdodges on FOD because he doesn't know where the side platforms are and regularly thinks he's "above" them and tries to waveland down (which causes the spotdodge, because he's grounded)