### PR TITLE
Remove unknown projectiles from gamestate.projectiles

### DIFF
--- a/esagent.py
+++ b/esagent.py
@@ -24,6 +24,11 @@ class ESAgent():
         xdist = gamestate.player[self.smashbot_port].x - gamestate.player[self.opponent_port].x
         ydist = gamestate.player[self.smashbot_port].y - gamestate.player[self.opponent_port].y
         gamestate.distance = math.sqrt( (xdist**2) + (ydist**2) )
+        knownprojectiles = []
+        for projectile in gamestate.projectiles:
+            if projectile.subtype != melee.enums.ProjectileSubtype.UNKNOWN_PROJECTILE:
+                newlist.append(projectile)
+        gamestate.projectiles = knownprojectiles
 
         self.strategy.step(gamestate,
                            gamestate.player[self.smashbot_port],


### PR DESCRIPTION
Smashbot was having issues on Yoshi's Story due to the presence of shy guys making him get stuck in shield. This removes unknown projectiles from gamestate.projectiles in ESAAgent.py