### PR TITLE
Shine OOS

### DIFF
--- a/Chains/__init__.py
+++ b/Chains/__init__.py
@@ -23,3 +23,4 @@ from Chains.tech import Tech
 from Chains.roll import Roll
 from Chains.edgebair import Edgebair
 from Chains.boardsideplatform import BoardSidePlatform
+from Chains.shieldaction import ShieldAction

--- a/Chains/shieldaction.py
+++ b/Chains/shieldaction.py
@@ -1,0 +1,103 @@
+import melee
+import Tactics
+from melee.enums import Action, Button
+from Chains.chain import Chain
+from enum import Enum
+
+class SHIELD_ACTION(Enum): #consider adding possibilities for angled tilts and turnaround tilts
+    PSSHINE = 0
+    PSUTILT = 1
+    PSDTILT = 2
+    PSJAB = 3
+
+class ShieldAction(Chain):
+    def __init__(self, action=SHIELD_ACTION.PSSHINE):
+        self.action = action
+
+    def step(self, gamestate, smashbot_state, opponent_state):
+        controller = self.controller
+
+        self.interruptible = True
+
+        # Let go of A if we were already pressing A
+        if controller.prev.button[Button.BUTTON_A]:
+            controller.empty_input()
+            return
+
+        # Let go of B if we were already pressing B
+        if controller.prev.button[Button.BUTTON_B]:
+            controller.empty_input()
+            return
+
+        # Consider adding redundancy to check for SHIELD_RELEASE, but this just has button inputs atm
+        if self.action == SHIELD_ACTION.PSSHINE:
+            controller.press_button(Button.BUTTON_B)
+            controller.tilt_analog(Button.BUTTON_MAIN, .5, .3)
+            return
+        if self.action == SHIELD_ACTION.PSUTILT:
+            controller.press_button(Button.BUTTON_A)
+            controller.tilt_analog(Button.BUTTON_MAIN, .5, 0.7)
+            return
+        elif self.action == SHIELD_ACTION.PSDTILT:
+            controller.press_button(Button.BUTTON_A)
+            controller.tilt_analog(Button.BUTTON_MAIN, .5, 0.3)
+            return
+        elif self.action == SHIELD_ACTION.PSJAB:
+            controller.press_button(Button.BUTTON_A)
+            return
+
+
+        #Do we need to jump cancel? #Jump canceling isn't valid for tilts
+        #jumpcancelactions = [Action.SHIELD, Action.DASHING, Action.RUNNING]
+        #if smashbot_state.action in jumpcancelactions:
+            #self.interruptible = False
+            #controller.press_button(Button.BUTTON_Y)
+            #return
+
+        # Jump out of shine #Jump canceling isn't valid for tilts
+        #isInShineStart = (smashbot_state.action == Action.DOWN_B_STUN or \
+            #smashbot_state.action == Action.DOWN_B_GROUND_START or \
+            #smashbot_state.action == Action.DOWN_B_GROUND)
+        #if isInShineStart and smashbot_state.action_frame >= 3 and smashbot_state.on_ground:
+            #self.interruptible = False
+            #controller.press_button(Button.BUTTON_Y)
+            #return
+
+        #this should not matter at all
+        #if smashbot_state.action in [Action.FSMASH_MID, Action.UPSMASH, Action.DOWNSMASH]:
+            # Are we in the early stages of the smash and need to charge?
+            #if self.frames_charged < self.charge:
+                #self.interruptible = False
+                #self.frames_charged += 1
+                #controller.press_button(Button.BUTTON_A)
+                #return
+            # Are we done with a smash and just need to quit?
+            #else:
+                 #self.interruptible = True
+                 #controller.empty_input()
+                 #return
+
+        #We need to input a jump to wavedash out of these states if dash/run gets called while in one of these states, or else we get stuck
+        #jcstates = [Action.DASHING]
+        #if (smashbot_state.action in jcstates):
+                #self.controller.press_button(Button.BUTTON_Y)
+                #return
+
+        # Airdodge for the wavedash
+        #jumping = [Action.JUMPING_ARIAL_FORWARD, Action.JUMPING_ARIAL_BACKWARD]
+        #jumpcancel = (smashbot_state.action == Action.KNEE_BEND) and (smashbot_state.action_frame == 3)
+        #if jumpcancel or smashbot_state.action in jumping:
+            #self.controller.press_button(Button.BUTTON_L)
+            #onleft = smashbot_state.x < endposition #don't know how to call endposition here
+            # Normalize distance from (0->1) to (0.5 -> 1)
+            #x = 1
+            #if onleft != True:
+                #x = -x
+            #self.controller.tilt_analog(Button.BUTTON_MAIN, x, 0.35)
+            #return
+
+        #Complete the pivot -- This block may be unnecessary if Fox can just tilt during Action.TURNING no matter what, he can't during tilt turn.
+        #if smashbot_state.action == Action.TURNING:
+            #controller.empty_input()
+            #self.interruptible = True
+            #return

--- a/Chains/shieldaction.py
+++ b/Chains/shieldaction.py
@@ -4,7 +4,7 @@ from melee.enums import Action, Button
 from Chains.chain import Chain
 from enum import Enum
 
-class SHIELD_ACTION(Enum): #consider adding possibilities for angled tilts and turnaround tilts
+class SHIELD_ACTION(Enum):
     PSSHINE = 0
     PSUTILT = 1
     PSDTILT = 2
@@ -45,59 +45,3 @@ class ShieldAction(Chain):
         elif self.action == SHIELD_ACTION.PSJAB:
             controller.press_button(Button.BUTTON_A)
             return
-
-
-        #Do we need to jump cancel? #Jump canceling isn't valid for tilts
-        #jumpcancelactions = [Action.SHIELD, Action.DASHING, Action.RUNNING]
-        #if smashbot_state.action in jumpcancelactions:
-            #self.interruptible = False
-            #controller.press_button(Button.BUTTON_Y)
-            #return
-
-        # Jump out of shine #Jump canceling isn't valid for tilts
-        #isInShineStart = (smashbot_state.action == Action.DOWN_B_STUN or \
-            #smashbot_state.action == Action.DOWN_B_GROUND_START or \
-            #smashbot_state.action == Action.DOWN_B_GROUND)
-        #if isInShineStart and smashbot_state.action_frame >= 3 and smashbot_state.on_ground:
-            #self.interruptible = False
-            #controller.press_button(Button.BUTTON_Y)
-            #return
-
-        #this should not matter at all
-        #if smashbot_state.action in [Action.FSMASH_MID, Action.UPSMASH, Action.DOWNSMASH]:
-            # Are we in the early stages of the smash and need to charge?
-            #if self.frames_charged < self.charge:
-                #self.interruptible = False
-                #self.frames_charged += 1
-                #controller.press_button(Button.BUTTON_A)
-                #return
-            # Are we done with a smash and just need to quit?
-            #else:
-                 #self.interruptible = True
-                 #controller.empty_input()
-                 #return
-
-        #We need to input a jump to wavedash out of these states if dash/run gets called while in one of these states, or else we get stuck
-        #jcstates = [Action.DASHING]
-        #if (smashbot_state.action in jcstates):
-                #self.controller.press_button(Button.BUTTON_Y)
-                #return
-
-        # Airdodge for the wavedash
-        #jumping = [Action.JUMPING_ARIAL_FORWARD, Action.JUMPING_ARIAL_BACKWARD]
-        #jumpcancel = (smashbot_state.action == Action.KNEE_BEND) and (smashbot_state.action_frame == 3)
-        #if jumpcancel or smashbot_state.action in jumping:
-            #self.controller.press_button(Button.BUTTON_L)
-            #onleft = smashbot_state.x < endposition #don't know how to call endposition here
-            # Normalize distance from (0->1) to (0.5 -> 1)
-            #x = 1
-            #if onleft != True:
-                #x = -x
-            #self.controller.tilt_analog(Button.BUTTON_MAIN, x, 0.35)
-            #return
-
-        #Complete the pivot -- This block may be unnecessary if Fox can just tilt during Action.TURNING no matter what, he can't during tilt turn.
-        #if smashbot_state.action == Action.TURNING:
-            #controller.empty_input()
-            #self.interruptible = True
-            #return

--- a/Tactics/edgeguard.py
+++ b/Tactics/edgeguard.py
@@ -485,7 +485,7 @@ class Edgeguard(Tactic):
                 self.chain = None
                 self.pickchain(Chains.DI, [0.5, 0.65])
                 return
-            framesleft = Punish.framesleft(opponent_state, self.framedata)
+            framesleft = Punish.framesleft(opponent_state, self.framedata, smashbot_state)
 
             # Samus UP_B invulnerability
             samusupbinvuln = opponent_state.action in [Action.SWORD_DANCE_3_MID, Action.SWORD_DANCE_3_LOW] and \
@@ -524,7 +524,7 @@ class Edgeguard(Tactic):
                 randomgrab = True
 
             # Can we challenge their ledge?
-            framesleft = Punish.framesleft(opponent_state, self.framedata)
+            framesleft = Punish.framesleft(opponent_state, self.framedata, smashbot_state)
             if not recoverhigh and not onedge and opponent_state.invulnerability_left < 5 and edgedistance < 10:
                 if randomgrab or framesleft > 10:
                     wavedash = True

--- a/Tactics/infinite.py
+++ b/Tactics/infinite.py
@@ -45,7 +45,7 @@ class Infinite(Tactic):
                 Action.WALK_SLOW, Action.WALK_MIDDLE, Action.WALK_FAST]:
             return False
 
-        framesleft = Punish.framesleft(opponent_state, framedata)
+        framesleft = Punish.framesleft(opponent_state, framedata, smashbot_state)
         # This is off by one for hitstun
         framesleft -= 1
 
@@ -87,7 +87,7 @@ class Infinite(Tactic):
             self.chain.step(gamestate, smashbot_state, opponent_state)
             return
 
-        framesleft = Punish.framesleft(opponent_state, self.framedata)
+        framesleft = Punish.framesleft(opponent_state, self.framedata, smashbot_state)
         # This is off by one for hitstun
         framesleft -= 1
 

--- a/Tactics/punish.py
+++ b/Tactics/punish.py
@@ -186,17 +186,12 @@ class Punish(Tactic):
 
         # Can we charge an upsmash right now?
         framesleft = Punish.framesleft(opponent_state, self.framedata, smashbot_state)
-
-        #Initialize these so we can log them too
         endposition = opponent_state.x + self.framedata.slide_distance(opponent_state, opponent_state.speed_x_attack, framesleft)
         slidedistance = self.framedata.slide_distance(smashbot_state, smashbot_state.speed_ground_x_self, framesleft)
         smashbot_endposition = slidedistance + smashbot_state.x
 
         if self.logger:
             self.logger.log("Notes", "framesleft: " + str(framesleft) + " ", concat=True)
-            self.logger.log("Notes", "initial endposition: " + str(endposition) + " ", concat=True)
-            self.logger.log("Notes", "initial smashbot_endposition: " + str(smashbot_endposition) + " ", concat=True)
-            self.logger.log("Notes", "distance: " + str(gamestate.distance) + " ", concat=True)
 
         #If we can't interrupt the chain, just continue it
         if self.chain != None and not self.chain.interruptible:
@@ -217,15 +212,8 @@ class Punish(Tactic):
         opponentyvelocity = (opponent_state.speed_y_attack + opponent_state.speed_y_self)
         opponentonright = opponent_state.x > smashbot_state.x
 
-        if powershieldrelease and framesleft >= 1:
-            """if abs(smashbot_state.x - opponent_state.x) <= 16 and opponent_state.y <= 12.5 and not (opponentxvelocity > 0) == opponentonright and gamestate.distance <= 12.5:
-                self.pickchain(Chains.ShieldAction, [SHIELD_ACTION.PSSHINE])
-                return
-            if abs(smashbot_state.x - opponent_state.x) <= 11 and opponent_state.y <= 12.5 and (opponentxvelocity > 0) == opponentonright and gamestate.distance <= 12.5:
-                self.pickchain(Chains.ShieldAction, [SHIELD_ACTION.PSSHINE])
-                return
-                #self.pickchain(Chains.SmashAttack, [framesleft-framesneeded-1, SMASH_DIRECTION.UP])"""
-            # Sometimes shine OOS will miss because the oppponent is still rising with an aerial. Peach's float is particularly problematic.
+        if powershieldrelease:
+            # Sometimes shine OOS will miss because the oppponent is still rising with an aerial. Peach's float can be hard to shine OOS.
             if opponent_state.y >= 11.5:
                 # If the opponent is above a certain height and still rising, or outside of a small x range, don't shine, just WD.
                 if opponentyvelocity >= 0 or abs(opponent_state.x - smashbot_state.x) > 6:
@@ -263,10 +251,7 @@ class Punish(Tactic):
                     self.pickchain(Chains.Waveshine)
                     return
             else:
-                """if smashbot_state.action in shieldactions and abs(smashbot_state.x - opponent_state.x) < 16 and opponent_state.y < 15 and framesleft >= 4:
-                    self.pickchain(Chains.Waveshine)
-                    return"""
-                if smashbot_state.action in shieldactions and gamestate.distance <= 13.2 and not (opponentxvelocity > 0) == opponentonright and framesleft >= 4:
+                if smashbot_state.action in shieldactions and gamestate.distance <= 12.2 and not (opponentxvelocity > 0) == opponentonright and framesleft >= 4:
                     self.pickchain(Chains.Waveshine)
                     return
                 if smashbot_state.action in shieldactions and gamestate.distance <= 11.5 and (opponentxvelocity > 0) == opponentonright and framesleft >= 4:
@@ -386,7 +371,7 @@ class Punish(Tactic):
                         self.pickchain(Chains.SmashAttack, [framesleft-framesneeded-1, SMASH_DIRECTION.UP])
                     return
                 else:
-                    if abs(smashbot_state.x) + 42 > melee.stages.EDGE_GROUND_POSITION[gamestate.stage] and opponent_state.percent < 89 and abs(opponent_state.x) < abs(smashbot_state.x) and distance < 9.9:
+                    if abs(smashbot_state.x) + 42 > melee.stages.EDGE_GROUND_POSITION[gamestate.stage] and opponent_state.percent < 89 and abs(opponent_state.x) < abs(smashbot_state.x) and gamestate.distance < 9.9:
                         self.pickchain(Chains.Waveshine, [x])
                     else:
                     # Do the bair if there's not enough time to wavedash, but we're facing away and out of shine range
@@ -400,7 +385,7 @@ class Punish(Tactic):
                             return
                         # If we are running away from our opponent, just shine now
                         onright = opponent_state.x < smashbot_state.x
-                        if (smashbot_state.speed_ground_x_self > 0) == onright and abs(opponent_state.x - smashbot_state.x) <= 9.5:
+                        if (smashbot_state.speed_ground_x_self > 0) == onright and gamestate.distance <= 9.5:
                             self.pickchain(Chains.Waveshine, [x])
                             return
                     return
@@ -456,7 +441,7 @@ class Punish(Tactic):
                         x = 0
                     # If we are running away from our opponent, just shine now
                     onright = opponent_state.x < smashbot_state.x
-                    if (smashbot_state.speed_ground_x_self > 0) == onright and abs(opponent_state.x - smashbot_state.x) <= 9.5:
+                    if (smashbot_state.speed_ground_x_self > 0) == onright and abs(gamestate.distance) <= 9.5:
                         self.pickchain(Chains.Waveshine, [x])
                         return
                     if framesleft in range(1,7):

--- a/Tactics/punish.py
+++ b/Tactics/punish.py
@@ -211,11 +211,13 @@ class Punish(Tactic):
             self.pickchain(Chains.Nothing)
             return
 
+        # Attempt powershield action, note, we don't have a way of knowing for sure if we hit a physical PS
         powershieldrelease = (smashbot_state.action == Action.SHIELD_RELEASE and smashbot_state.shield_strength == 60)
         opponentxvelocity = (opponent_state.speed_air_x_self + opponent_state.speed_ground_x_self + opponent_state.speed_x_attack)
         opponentyvelocity = (opponent_state.speed_y_attack + opponent_state.speed_y_self)
         opponentonright = opponent_state.x > smashbot_state.x
-        if powershieldrelease: #attempt powershield action, note, we don't have a way of knowing for sure if we hit a physical PS
+
+        if powershieldrelease and framesleft >= 1:
             """if abs(smashbot_state.x - opponent_state.x) <= 16 and opponent_state.y <= 12.5 and not (opponentxvelocity > 0) == opponentonright and gamestate.distance <= 12.5:
                 self.pickchain(Chains.ShieldAction, [SHIELD_ACTION.PSSHINE])
                 return
@@ -223,17 +225,23 @@ class Punish(Tactic):
                 self.pickchain(Chains.ShieldAction, [SHIELD_ACTION.PSSHINE])
                 return
                 #self.pickchain(Chains.SmashAttack, [framesleft-framesneeded-1, SMASH_DIRECTION.UP])"""
+            # Sometimes shine OOS will miss because the oppponent is still rising with an aerial. Peach's float is particularly problematic.
             if opponent_state.y >= 11.5:
+                # If the opponent is above a certain height and still rising, or outside of a small x range, don't shine, just WD.
                 if opponentyvelocity >= 0 or abs(opponent_state.x - smashbot_state.x) > 6:
                     self.pickchain(Chains.Wavedash)
                     return
+                # Shine otherwise (i.e. if they're above a certain height but falling towards us or in a certain x range)
                 else:
                     self.pickchain(Chains.ShieldAction, [SHIELD_ACTION.PSSHINE])
                     return
+            # If the opponent is closer to the ground
             else:
+                # PS shine if the opponent is drifting towards us
                 if gamestate.distance <= 14 and not (opponentxvelocity > 0) == opponentonright:
                     self.pickchain(Chains.ShieldAction, [SHIELD_ACTION.PSSHINE])
                     return
+                # PS shine if the opponent is drifting away from us
                 elif gamestate.distance <= 13 and (opponentxvelocity > 0) == opponentonright:
                     self.pickchain(Chains.ShieldAction, [SHIELD_ACTION.PSSHINE])
                     return
@@ -246,7 +254,8 @@ class Punish(Tactic):
 
         # JC Shine OOS if possible/necessary
         if framesleft in range(4,8):
-            if opponent_state.y >= 11.5:
+            # Numbers are adjusted from PS shine to be more conservative due to longer startup.
+            if opponent_state.y >= 11:
                 if opponentyvelocity >= 0 or abs(opponent_state.x - smashbot_state.x) > 5:
                     self.pickchain(Chains.Wavedash)
                     return
@@ -260,7 +269,7 @@ class Punish(Tactic):
                 if smashbot_state.action in shieldactions and gamestate.distance <= 13.2 and not (opponentxvelocity > 0) == opponentonright and framesleft >= 4:
                     self.pickchain(Chains.Waveshine)
                     return
-                if smashbot_state.action in shieldactions and gamestate.distance <= 12 and (opponentxvelocity > 0) == opponentonright and framesleft >= 4:
+                if smashbot_state.action in shieldactions and gamestate.distance <= 11.5 and (opponentxvelocity > 0) == opponentonright and framesleft >= 4:
                     self.pickchain(Chains.Waveshine)
                     return
 

--- a/Tactics/punish.py
+++ b/Tactics/punish.py
@@ -71,7 +71,7 @@ class Punish(Tactic):
                 return max(0, frame - opponent_state.action_frame - 1)
             if attackstate == melee.enums.AttackState.ATTACKING and smashbot_state.action == Action.SHIELD_RELEASE:
                 if opponent_state.action in [Action.NAIR, Action.FAIR, Action.UAIR, Action.BAIR, Action.DAIR]:
-                    return 9
+                    return 7
                 elif opponent_state.character == Character.PEACH and opponent_state.action in [Action.NEUTRAL_B_FULL_CHARGE, Action.WAIT_ITEM, Action.NEUTRAL_B_ATTACKING, Action.NEUTRAL_B_CHARGING, Action.NEUTRAL_B_FULL_CHARGE_AIR]:
                     return 6
                 else:
@@ -213,6 +213,7 @@ class Punish(Tactic):
 
         powershieldrelease = (smashbot_state.action == Action.SHIELD_RELEASE and smashbot_state.shield_strength == 60)
         opponentxvelocity = (opponent_state.speed_air_x_self + opponent_state.speed_ground_x_self + opponent_state.speed_x_attack)
+        opponentyvelocity = (opponent_state.speed_y_attack + opponent_state.speed_y_self)
         opponentonright = opponent_state.x > smashbot_state.x
         if powershieldrelease: #attempt powershield action, note, we don't have a way of knowing for sure if we hit a physical PS
             """if abs(smashbot_state.x - opponent_state.x) <= 16 and opponent_state.y <= 12.5 and not (opponentxvelocity > 0) == opponentonright and gamestate.distance <= 12.5:
@@ -222,26 +223,46 @@ class Punish(Tactic):
                 self.pickchain(Chains.ShieldAction, [SHIELD_ACTION.PSSHINE])
                 return
                 #self.pickchain(Chains.SmashAttack, [framesleft-framesneeded-1, SMASH_DIRECTION.UP])"""
-            if gamestate.distance <= 14.5 and not (opponentxvelocity > 0) == opponentonright:
-                self.pickchain(Chains.ShieldAction, [SHIELD_ACTION.PSSHINE])
-                return
-            if gamestate.distance <= 13 and (opponentxvelocity > 0) == opponentonright:
-                self.pickchain(Chains.ShieldAction, [SHIELD_ACTION.PSSHINE])
-                return
+            if opponent_state.y >= 11.5:
+                if opponentyvelocity >= 0 or abs(opponent_state.x - smashbot_state.x) > 6:
+                    self.pickchain(Chains.Wavedash)
+                    return
+                else:
+                    self.pickchain(Chains.ShieldAction, [SHIELD_ACTION.PSSHINE])
+                    return
+            else:
+                if gamestate.distance <= 14 and not (opponentxvelocity > 0) == opponentonright:
+                    self.pickchain(Chains.ShieldAction, [SHIELD_ACTION.PSSHINE])
+                    return
+                elif gamestate.distance <= 13 and (opponentxvelocity > 0) == opponentonright:
+                    self.pickchain(Chains.ShieldAction, [SHIELD_ACTION.PSSHINE])
+                    return
+                else:
+                    self.pickchain(Chains.Wavedash)
+                    return
 
         shieldactions = [Action.SHIELD_START, Action.SHIELD, Action.SHIELD_RELEASE, \
             Action.SHIELD_STUN, Action.SHIELD_REFLECT]
+
         # JC Shine OOS if possible/necessary
         if framesleft in range(4,8):
-            """if smashbot_state.action in shieldactions and abs(smashbot_state.x - opponent_state.x) < 16 and opponent_state.y < 15 and framesleft >= 4:
-                self.pickchain(Chains.Waveshine)
-                return"""
-            if smashbot_state.action in shieldactions and gamestate.distance <= 13.2 and not (opponentxvelocity > 0) == opponentonright and framesleft >= 4:
-                self.pickchain(Chains.Waveshine)
-                return
-            if smashbot_state.action in shieldactions and gamestate.distance <= 12 and (opponentxvelocity > 0) == opponentonright and framesleft >= 4:
-                self.pickchain(Chains.Waveshine)
-                return
+            if opponent_state.y >= 11.5:
+                if opponentyvelocity >= 0 or abs(opponent_state.x - smashbot_state.x) > 5:
+                    self.pickchain(Chains.Wavedash)
+                    return
+                else:
+                    self.pickchain(Chains.Waveshine)
+                    return
+            else:
+                """if smashbot_state.action in shieldactions and abs(smashbot_state.x - opponent_state.x) < 16 and opponent_state.y < 15 and framesleft >= 4:
+                    self.pickchain(Chains.Waveshine)
+                    return"""
+                if smashbot_state.action in shieldactions and gamestate.distance <= 13.2 and not (opponentxvelocity > 0) == opponentonright and framesleft >= 4:
+                    self.pickchain(Chains.Waveshine)
+                    return
+                if smashbot_state.action in shieldactions and gamestate.distance <= 12 and (opponentxvelocity > 0) == opponentonright and framesleft >= 4:
+                    self.pickchain(Chains.Waveshine)
+                    return
 
         # How many frames do we need for an upsmash?
         # It's 7 frames normally, plus some transition frames


### PR DESCRIPTION
-Added a chain for powershield actions (called ShieldAction)
-Fixed situations where smashbot was not going for shine OOS when he clearly could (most particularly, a) for very early aerials where Smashbot was actionable prior to the opponent's landing lag, and b) situations where framesleft was less than 7-8 but there was still time to shine OOS)
-Changed the framesleft function so that it would take in smashbot_state as well, since it did not before.