### PR TITLE
Boardsideplatform fixes

### DIFF
--- a/Chains/boardsideplatform.py
+++ b/Chains/boardsideplatform.py
@@ -48,8 +48,16 @@ class BoardSidePlatform(Chain):
             self.controller.tilt_analog(melee.Button.BUTTON_MAIN, 0.5, 0)
             return
 
+        # If we see the opponent jump, they cannot protect themselves from uair.
+        # Does not look for KNEE_BEND because Smashbot needs to discern between SH and FH
+        if shineable and opponent_state.action in [Action.JUMPING_FORWARD, Action.JUMPING_BACKWARD]:
+            self.controller.press_button(melee.Button.BUTTON_A)
+            self.controller.tilt_analog(melee.Button.BUTTON_MAIN, 0.5, 1)
+            return
+
         # Waveland down
-        if smashbot_state.ecb_bottom[1] + smashbot_state.y > platform_height:
+        aerials = [Action.NAIR, Action.FAIR, Action.UAIR, Action.BAIR, Action.DAIR]
+        if smashbot_state.ecb_bottom[1] + smashbot_state.y > platform_height and smashbot_state.action not in aerials:
             self.interruptible = True
             self.controller.press_button(melee.Button.BUTTON_L)
             self.controller.tilt_analog(melee.Button.BUTTON_MAIN, 0.5, 0)
@@ -74,6 +82,14 @@ class BoardSidePlatform(Chain):
                 self.controller.tilt_analog(melee.Button.BUTTON_MAIN, 1, .5)
                 return
             self.controller.tilt_analog(melee.Button.BUTTON_MAIN, int(smashbot_state.facing), .5)
+            return
+        # Mash analog L presses to L-cancel if Smashbot is throwing out an aerial
+        elif not smashbot_state.on_ground and smashbot_state.action in aerials:
+            self.interruptible = False
+            if gamestate.frame % 2 == 0:
+                self.controller.press_shoulder(Button.BUTTON_L, 1)
+            else:
+                self.controller.press_shoulder(Button.BUTTON_L, 0)
             return
         else:
             self.controller.empty_input()

--- a/Chains/boardsideplatform.py
+++ b/Chains/boardsideplatform.py
@@ -57,7 +57,8 @@ class BoardSidePlatform(Chain):
             return
 
         # Don't jump into Peach's dsmash or SH early dair spam
-        if shineable and opponent_state.action in [Action.DOWNSMASH, Action.DAIR]:
+        dsmashactive = opponent_state.action == Action.DOWNSMASH and opponent_state.action_frame <= 22
+        if shineable and (opponent_state.action == Action.DAIR or dsmashactive):
             self.interruptible = True
             self.controller.press_button(melee.Button.BUTTON_L)
             self.controller.tilt_analog(melee.Button.BUTTON_MAIN, 0.5, 0)

--- a/Tactics/punish.py
+++ b/Tactics/punish.py
@@ -200,6 +200,14 @@ class Punish(Tactic):
             self.pickchain(Chains.Nothing)
             return
 
+        framesneeded = 10
+        if framesneeded <= framesleft:
+            # If opponent is on a side platform and we're not
+            on_main_platform = smashbot_state.y < 1 and smashbot_state.on_ground
+            if opponent_state.y > 1 and opponent_state.on_ground and on_main_platform and gamestate.stage != melee.enums.Stage.FOUNTAIN_OF_DREAMS:
+                self.pickchain(Chains.BoardSidePlatform, [opponent_state.x > 0])
+                return
+                
         # How many frames do we need for an upsmash?
         # It's 7 frames normally, plus some transition frames
         # 3 if in shield, shine, or dash/running


### PR DESCRIPTION
Added an aggressive uair as an alternative to jump -> shine if the opponent jumps.
Can detect when the opponent will FH out of uair range.
Avoids jumping into dsmash spam and early SH dair spam.
Has a call to boardsideplatform from punish.py if the opponent does a laggy move (e.g. dsmash on platform).