### PR TITLE
Recovery fixes 2

### DIFF
--- a/Tactics/recover.py
+++ b/Tactics/recover.py
@@ -54,7 +54,7 @@ class Recover(Tactic):
         if opponent_dist < smashbot_dist and not onedge:
             return True
 
-        if smashbot_dist >= 92:
+        if smashbot_dist >= 100:
             return True
 
         # If opponent is ON the edge, recover
@@ -113,7 +113,9 @@ class Recover(Tactic):
             return
 
         # If we can just do nothing and grab the edge, do that
-        if -12 < smashbot_state.y and (diff_x < 10) and facinginwards and smashbot_state.speed_y_self < 0:
+        # Action.SWORD_DANCE_1_AIR is Fox's initial freefall after his upB finishes launching.
+        # Fox can ledgegrab from behind in this animation, but fastfalling helps him get the window.
+        if -12 < smashbot_state.y and (diff_x < 10) and (facinginwards or smashbot_state.action == Action.SWORD_DANCE_1_AIR) and smashbot_state.speed_y_self < 0:
             # Do a Fastfall if we're not already
             if smashbot_state.action == Action.FALLING and smashbot_state.speed_y_self > -3.3:
                 self.chain = None
@@ -155,7 +157,7 @@ class Recover(Tactic):
         # Is the opponent going offstage to edgeguard us?
         opponent_edgedistance = abs(opponent_state.x) - abs(melee.stages.EDGE_GROUND_POSITION[gamestate.stage])
         opponentxvelocity = opponent_state.speed_air_x_self + opponent_state.speed_ground_x_self
-        opponentmovingtoedge = (opponent_edgedistance < 20) and (opponentxvelocity > 0 == opponent_state.x > 0)
+        opponentmovingtoedge = not opponent_state.off_stage and (opponent_edgedistance < 20) and (opponentxvelocity > 0 == opponent_state.x > 0)
         opponentgoingoffstage = opponent_state.action in [Action.FALLING, Action.JUMPING_FORWARD, Action.JUMPING_BACKWARD, Action.LANDING_SPECIAL,\
         Action.DASHING, Action.WALK_MIDDLE, Action.WALK_FAST, Action.NAIR, Action.FAIR, Action.UAIR, Action.BAIR, Action.DAIR]
 
@@ -165,14 +167,15 @@ class Recover(Tactic):
         x = 0
         if smashbot_state.x < 0:
             x = 1
-        if x_canairdodge and y_canairdodge and (opponentgoingoffstage or airdodge_randomizer):
+        #if x_canairdodge and y_canairdodge and (opponentgoingoffstage or opponentmovingtoedge or airdodge_randomizer):
+        if x_canairdodge and y_canairdodge and (opponentgoingoffstage or opponentmovingtoedge):
             self.pickchain(Chains.Airdodge, [x, 1])
             return
 
         # First jump back to the stage if we're low
         # Fox can at least DJ from y = -55.43 and still sweetspot grab the ledge.
         # For reference, if Fox inputs a DJ at y = -58.83, he will NOT sweetspot grab the ledge.
-        jump_randomizer = random.randint(0, 3) == 1
+        jump_randomizer = random.randint(0, 5) == 1
         if smashbot_state.jumps_left > 0 and (smashbot_state.y < -52 or opponentgoingoffstage or opponentmovingtoedge or jump_randomizer):
             self.pickchain(Chains.Jump)
             return

--- a/Tactics/recover.py
+++ b/Tactics/recover.py
@@ -54,7 +54,7 @@ class Recover(Tactic):
         if opponent_dist < smashbot_dist and not onedge:
             return True
 
-        if smashbot_dist >= 100:
+        if smashbot_dist >= 125:
             return True
 
         # If opponent is ON the edge, recover
@@ -114,7 +114,7 @@ class Recover(Tactic):
 
         # If we can just do nothing and grab the edge, do that
         # Action.SWORD_DANCE_1_AIR is Fox's initial freefall after his upB finishes launching.
-        # Fox can ledgegrab from behind in this animation, but fastfalling helps him get the window.
+        # Fox can ledgegrab from behind in this animation, but he oftentimes needs to fastfall to hit the window.
         if -12 < smashbot_state.y and (diff_x < 10) and (facinginwards or smashbot_state.action == Action.SWORD_DANCE_1_AIR) and smashbot_state.speed_y_self < 0:
             # Do a Fastfall if we're not already
             if smashbot_state.action == Action.FALLING and smashbot_state.speed_y_self > -3.3:
@@ -137,7 +137,11 @@ class Recover(Tactic):
         # If we illusion at this range when the opponent is holding ledge, Smashbot dies.
         # Firefox instead if the opponent is grabbing edge. Opponent has to get up or get burned.
         if (-16.4 < smashbot_state.y < -5) and (diff_x < 10) and facinginwards and opponentonedge:
-            self.pickchain(Chains.Firefox, [FIREFOX.RANDOM])
+            if gamestate.stage == melee.enums.Stage.BATTLEFIELD:
+                # If Smashbot does a random or horizontal sideB here, he pretty reliably SDs on Battlefield
+                self.pickchain(Chains.Firefox, [FIREFOX.EDGE])
+            else:
+                self.pickchain(Chains.Firefox, [FIREFOX.RANDOM])
             return
 
         # If we're lined up, do the illusion
@@ -163,11 +167,11 @@ class Recover(Tactic):
 
         x_canairdodge = abs(smashbot_state.x) - 18 <= abs(melee.stages.EDGE_GROUND_POSITION[gamestate.stage])
         y_canairdodge = smashbot_state.y + 18 >= -6
+        # airdodge_randomizer not currently in use
         airdodge_randomizer = random.randint(0, 4) == 1
         x = 0
         if smashbot_state.x < 0:
             x = 1
-        #if x_canairdodge and y_canairdodge and (opponentgoingoffstage or opponentmovingtoedge or airdodge_randomizer):
         if x_canairdodge and y_canairdodge and (opponentgoingoffstage or opponentmovingtoedge):
             self.pickchain(Chains.Airdodge, [x, 1])
             return
@@ -205,8 +209,6 @@ class Recover(Tactic):
             else:
                 self.pickchain(Chains.Illusion, [SHORTEN.LONG])
             return
-
-
 
         # DI into the stage
         battlefielded = (smashbot_state.x < melee.stages.EDGE_POSITION[gamestate.stage] + 13) and gamestate.stage == melee.enums.Stage.BATTLEFIELD and smashbot_state.y < 0


### PR DESCRIPTION
Added another SD fix on Battlefield when he upB'd too close to ledge
Adjusted fastfall after upB so he can get the reverse ledgegrab if facing away
Adjusted emergency needsrecovery code distance value from 100 to 125
Uses "opponentmovingtoedge" variable to detect airdodge conditions (this variable was initialized previously but forgot to use it)
Reverted random airdodge (seemed to be causing excessive airdodges sometimes, hard to replicate)